### PR TITLE
voodoospark firmware via Spark-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Vspark is a Go package that lets you write programs for [Spark devices] (https:/
 
 Load the [Voodoospark firmware] (https://github.com/voodootikigod/voodoospark) onto your Spark device. 
 
+*For users familiar with [Spark-cli] (https://github.com/spark/spark-cli), voodoospark firmware is bundled and can be flashed through the CLI.
+
 Set these environment variables on the host machine.
 
 ```go


### PR DESCRIPTION
Adding in description for easier flashing of voodoospark firmware for users familiar with Spark-cli.

Eg.

```
#flash via Cloud OTA
spark flash core_id voodoo

OR

#flash via USB DFU
spark flash --usb voodoo
```
